### PR TITLE
Update pure-render-mixin in lib/PrismCode.js for React 14 compatibility

### DIFF
--- a/lib/PrismCode.js
+++ b/lib/PrismCode.js
@@ -18,7 +18,7 @@ var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactPureRenderFunction = require("react-pure-render/function");
+var _reactPureRenderFunction = require('react-addons-pure-render-mixin');
 
 var _reactPureRenderFunction2 = _interopRequireDefault(_reactPureRenderFunction);
 


### PR DESCRIPTION
React14 now separates add-ons and you have to explicitly include them: https://facebook.github.io/react/docs/pure-render-mixin.html