### PR TITLE
Allow to configure the wrapper component and use ref-callback instead…

### DIFF
--- a/src/lib/PrismCode.js
+++ b/src/lib/PrismCode.js
@@ -14,6 +14,7 @@ export default class PrismCode extends PureComponent {
     async: PropTypes.bool,
     className: PropTypes.string,
     children: PropTypes.any,
+    component: PropTypes.node,
   };
 
   componentDidMount() {
@@ -25,22 +26,24 @@ export default class PrismCode extends PureComponent {
   }
 
   _hightlight() {
-    Prism.highlightElement(this.refs.code, this.props.async);
+    Prism.highlightElement(this._domNode, this.props.async);
   }
 
   render() {
     const {
       className,
       children,
+      component,
     } = this.props;
-
+    
+    const Wrapper = component ? component : `code`;
     return (
-      <code
-        ref="code"
+      <Wrapper
+        ref={domeNode => this._domNode = domeNode}
         className={className}
       >
         {children}
-      </code>
+      </Wrapper>
     );
   }
 }

--- a/src/lib/PrismCode.js
+++ b/src/lib/PrismCode.js
@@ -39,7 +39,7 @@ export default class PrismCode extends PureComponent {
     const Wrapper = component ? component : `code`;
     return (
       <Wrapper
-        ref={domeNode => this._domNode = domeNode}
+        ref={domNode => this._domNode = domNode}
         className={className}
       >
         {children}


### PR DESCRIPTION
… of deprecated string-ref

I need to use a `pre`-tag instead of a `code`-block to preserve line-breaks.
